### PR TITLE
feat: manage charge section

### DIFF
--- a/components/ConfigurationPane/EditDeleteChargesSection.tsx
+++ b/components/ConfigurationPane/EditDeleteChargesSection.tsx
@@ -8,14 +8,14 @@ import { Trash2 } from 'react-feather';
 
 type EditDeleteChargesSectionProps = {
 	charges: PointCharge[];
-	onDeleteHandler: (chargeName: string) => void;
-	onEditHandler: (charge: PointCharge) => void;
+	onDeleteCharge: (chargeName: string) => void;
+	onEditCharge: (charge: PointCharge) => void;
 };
 
 const EditDeleteChargesSection: React.FC<EditDeleteChargesSectionProps> = ({
 	charges,
-	onDeleteHandler,
-	onEditHandler,
+	onDeleteCharge,
+	onEditCharge,
 }) => {
 	return (
 		<Wrapper>
@@ -24,14 +24,14 @@ const EditDeleteChargesSection: React.FC<EditDeleteChargesSectionProps> = ({
 				const onInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
 					const newCharge = {
 						...charge,
-						q: event.target.value,
-					} as any as PointCharge;
-					onEditHandler(newCharge);
+						q: parseInt(event.target.value),
+					} as PointCharge;
+					onEditCharge(newCharge);
 				};
 				const onIconClick: React.MouseEventHandler<SVGElement> = (
 					event: React.MouseEvent<SVGElement>
 				) => {
-					onDeleteHandler(charge.name);
+					onDeleteCharge(charge.name);
 				};
 				const lawLatex = `$${charge.name.split(' ').join('\\ ')}:\\ q = \\ $`;
 				return (

--- a/components/ConfigurationPane/EditDeleteChargesSection.tsx
+++ b/components/ConfigurationPane/EditDeleteChargesSection.tsx
@@ -1,0 +1,66 @@
+import styled from '@emotion/styled';
+import { PointCharge } from 'cs-zeus';
+import Paragraph from '../ui/Paragraph';
+import SectionTitle from '../ui/SectionTitle';
+import TextField from '../ui/TextField';
+import Latex from 'react-latex-next';
+import { Trash2 } from 'react-feather';
+
+type EditDeleteChargesSectionProps = {
+	charges: PointCharge[];
+	onDeleteHandler: (chargeName: string) => void;
+	onEditHandler: (charge: PointCharge) => void;
+};
+
+const EditDeleteChargesSection: React.FC<EditDeleteChargesSectionProps> = ({
+	charges,
+	onDeleteHandler,
+	onEditHandler,
+}) => {
+	return (
+		<Wrapper>
+			<SectionTitle>Manage Charges</SectionTitle>
+			{charges.map((charge) => {
+				const onInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+					const newCharge = {
+						...charge,
+						q: event.target.value,
+					} as any as PointCharge;
+					onEditHandler(newCharge);
+				};
+				const onIconClick: React.MouseEventHandler<SVGElement> = (
+					event: React.MouseEvent<SVGElement>
+				) => {
+					onDeleteHandler(charge.name);
+				};
+				const lawLatex = `$${charge.name.split(' ').join('\\ ')}:\\ q = \\ $`;
+				return (
+					<StyledParagraph key={'edit-delete-charges-' + charge.name}>
+						<Latex>{lawLatex}</Latex>
+						<TextField value={charge.q} onChange={onInputChange} />
+						<StyledTrash onClick={onIconClick} />
+					</StyledParagraph>
+				);
+			})}
+		</Wrapper>
+	);
+};
+
+const Wrapper = styled.div`
+	background-color: var(--primary-color);
+	width: 100%;
+	padding: 1rem 1rem 1rem 2rem;
+	color: var(--white);
+`;
+
+const StyledParagraph = styled(Paragraph)`
+	margin-top: 0.5rem;
+	color: var(--white);
+`;
+
+const StyledTrash = styled(Trash2)`
+	margin-left: 8px;
+	vertical-align: bottom;
+`;
+
+export default EditDeleteChargesSection;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -53,8 +53,8 @@ const Home: NextPage = () => {
 					ConfigurationPane
 					<EditDeleteChargesSection
 						charges={charges}
-						onEditHandler={editChargeHandler}
-						onDeleteHandler={removePointChargeHandler}
+						onEditCharge={editChargeHandler}
+						onDeleteCharge={removePointChargeHandler}
 					/>
 					<CalculationResultSection charges={charges} testCharge={testCharge} />
 					<Footer onClickExplanationLink={openModalHandler} />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,6 +7,7 @@ import { useAppConfig } from '../hooks/useAppConfig';
 import { usePointCharges } from '../hooks/usePointCharges';
 import CalculationResultSection from '../components/ConfigurationPane/CalculationResultSection';
 import Footer from '../components/ConfigurationPane/Footer';
+import EditDeleteChargesSection from '../components/ConfigurationPane/EditDeleteChargesSection';
 
 const Home: NextPage = () => {
 	const {
@@ -50,6 +51,11 @@ const Home: NextPage = () => {
 				</LeftPane>
 				<RightPane>
 					ConfigurationPane
+					<EditDeleteChargesSection
+						charges={charges}
+						onEditHandler={editChargeHandler}
+						onDeleteHandler={removePointChargeHandler}
+					/>
 					<CalculationResultSection charges={charges} testCharge={testCharge} />
 					<Footer onClickExplanationLink={openModalHandler} />
 				</RightPane>


### PR DESCRIPTION
<img width="437" alt="Screen Shot 2021-10-20 at 23 36 30" src="https://user-images.githubusercontent.com/42907115/138134565-c263b826-34de-419c-9194-184743a9fe1d.png">

# Issue
<img width="1456" alt="Screen Shot 2021-10-20 at 23 37 04" src="https://user-images.githubusercontent.com/42907115/138134670-f4b83a2c-223f-49a1-9afa-9907aef37521.png">

Modify/delete the charge will not reflect in the simulation pane, but it changes the state. Drag and drop charge from simulation pane also set the charges to initial value
